### PR TITLE
Change comments orders

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -31,7 +31,7 @@ module Budgets
 
     feature_flag :budgets
 
-    has_orders %w[most_voted newest oldest], only: :show
+    has_orders %w[newest most_voted oldest], only: :show
     has_orders ->(c) { c.instance_variable_get(:@budget).investments_orders }, only: :index
     has_filters ->(c) { c.instance_variable_get(:@budget).investments_filters }, only: [:index, :show, :suggest]
 

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -13,7 +13,7 @@ class DebatesController < ApplicationController
   invisible_captcha only: [:create, :update], honeypot: :subtitle
 
   has_orders ->(c) { Debate.debates_orders(c.current_user) }, only: :index
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   load_and_authorize_resource
   helper_method :resource_model, :resource_name

--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -8,7 +8,7 @@ class Legislation::AnnotationsController < Legislation::BaseController
   load_and_authorize_resource :draft_version, through: :process
   load_and_authorize_resource
 
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   def index
     @annotations = @draft_version.annotations

--- a/app/controllers/legislation/proposals_controller.rb
+++ b/app/controllers/legislation/proposals_controller.rb
@@ -12,7 +12,7 @@ class Legislation::ProposalsController < Legislation::BaseController
 
   invisible_captcha only: [:create, :update], honeypot: :subtitle
 
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   helper_method :resource_model, :resource_name
   respond_to :html, :js

--- a/app/controllers/legislation/questions_controller.rb
+++ b/app/controllers/legislation/questions_controller.rb
@@ -2,7 +2,7 @@ class Legislation::QuestionsController < Legislation::BaseController
   load_and_authorize_resource :process
   load_and_authorize_resource :question, through: :process
 
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   def show
     @commentable = @question

--- a/app/controllers/polls/questions_controller.rb
+++ b/app/controllers/polls/questions_controller.rb
@@ -2,7 +2,7 @@ class Polls::QuestionsController < ApplicationController
   load_and_authorize_resource :poll
   load_and_authorize_resource :question, class: "Poll::Question"
 
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   def answer
     answer = @question.answers.find_or_initialize_by(author: current_user)

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -10,7 +10,7 @@ class PollsController < ApplicationController
   load_and_authorize_resource
 
   has_filters %w[current expired]
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   def index
     @polls = Kaminari.paginate_array(

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -19,7 +19,7 @@ class ProposalsController < ApplicationController
   invisible_captcha only: [:create, :update], honeypot: :subtitle
 
   has_orders ->(c) { Proposal.proposals_orders(c.current_user) }, only: :index
-  has_orders %w[most_voted newest oldest], only: :show
+  has_orders %w[newest most_voted oldest], only: :show
 
   load_and_authorize_resource
   helper_method :resource_model, :resource_name

--- a/spec/controllers/custom/budgets/investments_controller_spec.rb
+++ b/spec/controllers/custom/budgets/investments_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Budgets::InvestmentsController do
+  describe "GET show" do
+    let(:investment) { create(:budget_investment) }
+
+    it "has custom order for comments" do
+      get :show, params: { budget_id: investment.budget.id, id: investment.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/debates_controller_spec.rb
+++ b/spec/controllers/custom/debates_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe DebatesController do
+  describe "GET show" do
+    let(:debate) { create(:debate) }
+
+    it "has custom order for comments" do
+      get :show, params: { id: debate.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/legislation/annotations_controller_spec.rb
+++ b/spec/controllers/custom/legislation/annotations_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Legislation::AnnotationsController do
+  describe "GET show" do
+    let(:annotation) { create(:legislation_annotation) }
+
+    it "has custom order for comments" do
+      get :show, params: { process_id: annotation.draft_version.process.id,
+                           draft_version_id: annotation.draft_version.id,
+                           id: annotation.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/legislation/proposals_controller_spec.rb
+++ b/spec/controllers/custom/legislation/proposals_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Legislation::ProposalsController do
+  describe "GET show" do
+    let(:proposal) { create(:legislation_proposal) }
+
+    it "has custom order for comments" do
+      get :show, params: { process_id: proposal.process.id, id: proposal.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/legislation/questions_controller_spec.rb
+++ b/spec/controllers/custom/legislation/questions_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe Legislation::QuestionsController do
+  describe "GET show" do
+    let(:question) { create(:legislation_question) }
+
+    it "has custom order for comments" do
+      get :show, params: { process_id: question.process.id, id: question.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/polls_controller_spec.rb
+++ b/spec/controllers/custom/polls_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe PollsController do
+  describe "GET show" do
+    let(:poll) { create(:poll) }
+
+    it "has custom order for comments" do
+      get :show, params: { id: poll.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end

--- a/spec/controllers/custom/proposals_controller_spec.rb
+++ b/spec/controllers/custom/proposals_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe ProposalsController do
+  describe "GET show" do
+    let(:proposal) { create(:proposal) }
+
+    it "has custom order for comments" do
+      get :show, params: { id: proposal.id }
+      expect(controller.valid_orders).to eq %w[newest most_voted oldest]
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Change comments orders from `Most voted / Newest / Oldest` to `Newest / Most voted / Oldest`.

