### PR TITLE
Fix small only breakpoint

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -811,7 +811,7 @@ body > header,
 
 .locale .locale-form {
 
-  @include breakpoint(small-only) {
+  @include breakpoint(small only) {
     padding-left: $line-height / 4;
   }
 }


### PR DESCRIPTION
## Objectives

Fix small only breakpoint.

## Notes

Prevent warning message when run some specs:

```
WARNING: breakpoint(): "small-only" is not defined in your `$breakpoints` or `$breakpoints-hidpi` setting.
         on line 92:7 of ../../.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_breakpoint.scss, in function `breakpoint`
         from line 152:11 of ../../.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_breakpoint.scss, in mixin `breakpoint`
         from line 800:12 of app/assets/stylesheets/base.scss
         from line 55:9 of app/assets/stylesheets/application.scss
```
