### PR TITLE
Fix word wrap on poll results

### DIFF
--- a/app/assets/stylesheets/custom/custom.scss
+++ b/app/assets/stylesheets/custom/custom.scss
@@ -109,3 +109,7 @@ h1 {
 .poll-question .button {
   width: 100%;
 }
+
+.polls-results-stats table th {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
## Objectives

Fix word wrap on poll results.

## Visual Changes

### Before
<img width="903" alt="before" src="https://github.com/0ldenzaal/consul/assets/631897/8d32f550-9cb2-41a6-84cf-bd856e9f0b80">

### After
<img width="899" alt="after" src="https://github.com/0ldenzaal/consul/assets/631897/6a0428a8-c7de-42f3-939a-e9f0868f3608">

